### PR TITLE
Improve game interface error feedback

### DIFF
--- a/juegoahorcado/src/main/java/es/franciscorodalf/juegoahorcado/frontend/controller/juegoController.java
+++ b/juegoahorcado/src/main/java/es/franciscorodalf/juegoahorcado/frontend/controller/juegoController.java
@@ -41,9 +41,11 @@ public class juegoController extends Conexion {
     @FXML
     private Canvas canvas;          
     @FXML
-    private Button btnProbar;         
+    private Button btnProbar;
     @FXML
-    private Label letrasUsadasLabel; 
+    private Label letrasUsadasLabel;
+    @FXML
+    private Label errorLabel;
 
     private UsuarioEntity usuario;          
     private String palabraSecreta;           
@@ -58,6 +60,9 @@ public class juegoController extends Conexion {
     @FXML
     public void initialize() {
         btnProbar.setOnAction(this::probarLetra);
+        if (errorLabel != null) {
+            errorLabel.setText("");
+        }
     }
 
     /**
@@ -84,6 +89,9 @@ public class juegoController extends Conexion {
         errores = 0;
         letrasUsadas.clear();
         actualizarLetrasUsadas();
+        if (errorLabel != null) {
+            errorLabel.setText("");
+        }
         dibujarBase();
     }
 
@@ -129,15 +137,24 @@ public class juegoController extends Conexion {
      */
     private void probarLetra(ActionEvent event) {
         String letra = inputLetra.getText().trim().toLowerCase();
-        if (letra.length() != 1 || !letra.matches("[a-zA-ZñÑ]")) {
-            mostrarAlerta("Letra no válida", "Introduce solo una letra.");
+        if (letra.isEmpty()) {
+            mostrarError("No has ingresado ninguna letra");
+            return;
+        }
+        if (letra.length() > 1) {
+            mostrarError("Ingresa solo una letra");
+            return;
+        }
+        if (!letra.matches("[a-zA-ZñÑ]")) {
+            mostrarError("Carácter no válido");
             return;
         }
         char letraChar = letra.charAt(0);
         if (letrasUsadas.contains(letraChar)) {
-            mostrarAlerta("Letra repetida", "Ya has usado esa letra.");
+            mostrarError("Ya has usado esa letra");
             return;
         }
+        mostrarError("");
 
         letrasUsadas.add(letraChar);
         actualizarLetrasUsadas();
@@ -247,7 +264,17 @@ public class juegoController extends Conexion {
         alert.setHeaderText(null);
         alert.setContentText(contenido);
         alert.showAndWait();
-        
+
+    }
+
+    /**
+     * Muestra un mensaje de error en la interfaz de juego
+     * @param mensaje Texto a mostrar
+     */
+    private void mostrarError(String mensaje) {
+        if (errorLabel != null) {
+            errorLabel.setText(mensaje);
+        }
     }
 
     /**

--- a/juegoahorcado/src/main/resources/css/game.css
+++ b/juegoahorcado/src/main/resources/css/game.css
@@ -79,3 +79,9 @@
 .restart-button:hover {
     -fx-background-color: derive(-color-secondary, -10%);
 }
+
+/* Label para mostrar mensajes de error en la pantalla de juego */
+.error-label {
+    -fx-text-fill: -color-error;
+    -fx-font-weight: bold;
+}

--- a/juegoahorcado/src/main/resources/es/franciscorodalf/juegoahorcado/juego.fxml
+++ b/juegoahorcado/src/main/resources/es/franciscorodalf/juegoahorcado/juego.fxml
@@ -11,7 +11,7 @@
 
 <AnchorPane prefHeight="600.0" prefWidth="400.0" styleClass="anchor-pane" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="es.franciscorodalf.juegoahorcado.frontend.controller.juegoController">
 
-    <VBox alignment="CENTER" layoutX="10.0" layoutY="11.0" spacing="15" styleClass="game-container" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="11.0">
+    <VBox alignment="CENTER" layoutX="10.0" layoutY="11.0" spacing="15" styleClass="game-container" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="11.0" AnchorPane.bottomAnchor="11.0">
         
         <!-- Datos del usuario -->
         <HBox spacing="30" styleClass="user-info">

--- a/juegoahorcado/src/main/resources/es/franciscorodalf/juegoahorcado/juego.fxml
+++ b/juegoahorcado/src/main/resources/es/franciscorodalf/juegoahorcado/juego.fxml
@@ -38,6 +38,8 @@
             <TextField fx:id="inputLetra" maxWidth="70.0" prefHeight="40.0" promptText="Letra" styleClass="letter-input" />
             <Button fx:id="btnProbar" prefHeight="40.0" prefWidth="100.0" text="Probar" styleClass="try-button" />
         </HBox>
+        <!-- Mensajes de error -->
+        <Label fx:id="errorLabel" text="" styleClass="error-label" />
 
         <!-- Letras usadas -->
         <VBox alignment="CENTER" spacing="5" styleClass="used-letters-container">


### PR DESCRIPTION
## Summary
- add onscreen error label to juego view
- style the error label with red text
- show validation messages on the screen instead of alerts

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a89dbaab8832db2c027b8233cd2b7